### PR TITLE
Use full command line for builder_id generation

### DIFF
--- a/src/engine/SCons/Spirent/__init__.py
+++ b/src/engine/SCons/Spirent/__init__.py
@@ -104,9 +104,8 @@ class GraphWriter(object):
 
     def _get_builder_id(self, act, target, source, env):
         # Get the contents of the action command line and hash it
-        from SCons.Subst import SUBST_CMD
         cmd = act.genstring(target, source, env)
-        return abs(hash(str(env.subst_target_source(cmd, SUBST_CMD, target, source))))
+        return abs(hash(str(env.subst_target_source(cmd, SCons.Subst.SUBST_CMD, target, source))))
 
     def _write_derived_node(self, f, node_id, path, is_root):
         path = self._path_transform(path)

--- a/src/engine/SCons/Spirent/__init__.py
+++ b/src/engine/SCons/Spirent/__init__.py
@@ -9,6 +9,7 @@ import subprocess
 import SCons.Action
 import SCons.Node
 import SCons.SConf
+import SCons.Subst
 
 def vulcan_builder(fs, options, graph):
     # Get the vulcan command line options
@@ -148,7 +149,10 @@ class GraphWriter(object):
                 target = [node]
                 source = node.sources
                 env = node.env or node.builder.env
-                builder_id = abs(hash(str(act.get_presig(target, source, env))))
+                # Get the contents of the action command line and hash it
+                from SCons.Subst import SUBST_CMD
+                cmd = act.genstring(target, source, env)
+                builder_id = abs(hash(str(env.subst_target_source(cmd, SUBST_CMD, target, source))))
                 if builder_id not in visited:
                     visited.add(builder_id)
                     cmdlines = self._get_node_cmdlines(node, act, target, source, env)

--- a/src/engine/SCons/Spirent/__init__.py
+++ b/src/engine/SCons/Spirent/__init__.py
@@ -102,6 +102,12 @@ class GraphWriter(object):
     def _get_node_mode(self, path):
         return oct(os.stat(path).st_mode & 0777)
 
+    def _get_builder_id(self, act, target, source, env):
+        # Get the contents of the action command line and hash it
+        from SCons.Subst import SUBST_CMD
+        cmd = act.genstring(target, source, env)
+        return abs(hash(str(env.subst_target_source(cmd, SUBST_CMD, target, source))))
+
     def _write_derived_node(self, f, node_id, path, is_root):
         path = self._path_transform(path)
         attrs = 'type=derived,path=' + json.dumps(path)
@@ -149,10 +155,7 @@ class GraphWriter(object):
                 target = [node]
                 source = node.sources
                 env = node.env or node.builder.env
-                # Get the contents of the action command line and hash it
-                from SCons.Subst import SUBST_CMD
-                cmd = act.genstring(target, source, env)
-                builder_id = abs(hash(str(env.subst_target_source(cmd, SUBST_CMD, target, source))))
+                builder_id = self._get_builder_id(act, target, source, env)
                 if builder_id not in visited:
                     visited.add(builder_id)
                     cmdlines = self._get_node_cmdlines(node, act, target, source, env)


### PR DESCRIPTION
Use full command line instead of command signature for builder_id generation